### PR TITLE
feat: Add task category field with work, personal, and urgent options

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,10 +1,13 @@
 import express from 'express';
 import cors from 'cors';
 
+type TaskCategory = 'work' | 'personal' | 'urgent';
+
 interface Task {
     id: number;
     title: string;
     completed: boolean;
+    category: TaskCategory;
     createdAt: Date;
 }
 
@@ -26,16 +29,23 @@ app.get('/api/tasks', (req, res) => {
 // Add a new task
 app.post('/api/tasks', (req, res) => {
     console.log('Received request body:', req.body);
-    const { title } = req.body;
+    const { title, category } = req.body;
     if (!title) {
         console.log('Title is missing');
         return res.status(400).json({ error: 'Title is required' });
+    }
+    
+    // Validate category
+    const validCategories: TaskCategory[] = ['work', 'personal', 'urgent'];
+    if (category && !validCategories.includes(category)) {
+        return res.status(400).json({ error: 'Invalid category. Must be work, personal, or urgent' });
     }
 
     const newTask: Task = {
         id: nextId++,
         title,
         completed: false,
+        category: category || 'personal', // Default to 'personal' if not provided
         createdAt: new Date()
     };
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -41,6 +41,8 @@
   display: flex;
   gap: 10px;
   justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .task-input__field {
@@ -49,6 +51,15 @@
   border: 1px solid #ccc;
   border-radius: 4px;
   width: 300px;
+}
+
+.task-input__category {
+  padding: 8px 12px;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: white;
+  cursor: pointer;
 }
 
 .task-input__button {
@@ -88,6 +99,34 @@
 
 .task-item__checkbox {
   margin: 0;
+}
+
+.task-category {
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: bold;
+  text-transform: capitalize;
+  min-width: 80px;
+  text-align: center;
+}
+
+.task-category--work {
+  background-color: #e3f2fd;
+  color: #1976d2;
+  border: 1px solid #bbdefb;
+}
+
+.task-category--personal {
+  background-color: #f3e5f5;
+  color: #7b1fa2;
+  border: 1px solid #e1bee7;
+}
+
+.task-category--urgent {
+  background-color: #ffebee;
+  color: #d32f2f;
+  border: 1px solid #ffcdd2;
 }
 
 .task-item__title {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import TaskInput from './components/TaskInput';
 import TaskList from './components/TaskList';
-import { Task } from './types';
+import { Task, TaskCategory } from './types';
 import './App.css';
 
 
@@ -34,16 +34,16 @@ function App() {
     }
   };
 
-  const addTask = async (title: string) => {
+  const addTask = async (title: string, category: TaskCategory) => {
     setError(null);
     try {
-      console.log('Sending request to add task:', { title });
+      console.log('Sending request to add task:', { title, category });
       const response = await fetch(`${API_URL}/tasks`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ title }),
+        body: JSON.stringify({ title, category }),
       });
       
       const responseData = await response.json();

--- a/frontend/src/components/TaskInput.tsx
+++ b/frontend/src/components/TaskInput.tsx
@@ -1,17 +1,20 @@
 import React, { useState } from 'react';
+import { TaskCategory } from '../types';
 
 interface TaskInputProps {
-    onAddTask: (title: string) => Promise<void>;
+    onAddTask: (title: string, category: TaskCategory) => Promise<void>;
 }
 
 const TaskInput: React.FC<TaskInputProps> = ({ onAddTask }) => {
     const [title, setTitle] = useState('');
+    const [category, setCategory] = useState<TaskCategory>('personal');
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         if (title.trim()) {
-            await onAddTask(title);
+            await onAddTask(title, category);
             setTitle('');
+            setCategory('personal');
         }
     };
 
@@ -24,6 +27,15 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask }) => {
                 placeholder="Add a new task..."
                 className="task-input__field"
             />
+            <select
+                value={category}
+                onChange={(e) => setCategory(e.target.value as TaskCategory)}
+                className="task-input__category"
+            >
+                <option value="personal">Personal</option>
+                <option value="work">Work</option>
+                <option value="urgent">Urgent</option>
+            </select>
             <button type="submit" className="task-input__button">
                 Add Task
             </button>

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -8,6 +8,19 @@ interface TaskListProps {
 }
 
 const TaskList: React.FC<TaskListProps> = ({ tasks, onToggleTask, onDeleteTask }) => {
+    const getCategoryIcon = (category: string) => {
+        switch (category) {
+            case 'work': return '💼';
+            case 'urgent': return '🚨';
+            case 'personal': return '👤';
+            default: return '📝';
+        }
+    };
+
+    const getCategoryClass = (category: string) => {
+        return `task-category task-category--${category}`;
+    };
+
     return (
         <ul className="task-list">
             {tasks.map((task) => (
@@ -18,6 +31,9 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onToggleTask, onDeleteTask }
                         onChange={() => onToggleTask(task.id)}
                         className="task-item__checkbox"
                     />
+                    <span className={getCategoryClass(task.category)}>
+                        {getCategoryIcon(task.category)} {task.category}
+                    </span>
                     <span className="task-item__title">{task.title}</span>
                     <button
                         onClick={() => onDeleteTask(task.id)}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,6 +1,9 @@
+export type TaskCategory = 'work' | 'personal' | 'urgent';
+
 export interface Task {
     id: number;
     title: string;
     completed: boolean;
+    category: TaskCategory;
     createdAt: Date;
 }


### PR DESCRIPTION
- Add TaskCategory type with 'work', 'personal', 'urgent' options
- Update Task interface to include category field in both frontend and backend
- Add category dropdown to TaskInput component with validation
- Display categories with icons and color-coded badges in TaskList
- Update API endpoints to handle category field with validation
- Add responsive CSS styling for category selection and display
- Default category is set to 'personal' when not specified

Features:
- Category selection dropdown in task creation form
- Visual category indicators with emojis ( work,  urgent,  personal)
- Color-coded category badges (blue for work, purple for personal, red for urgent)
- Backend validation for category values
- Backward compatibility with existing tasks